### PR TITLE
[rake_helper: notifications fix] Extending the logging methods to accept notification params

### DIFF
--- a/change_log/v1_0_1.md
+++ b/change_log/v1_0_1.md
@@ -1,0 +1,3 @@
+# v1.0.1 (2016-09-19)
+
+Adding handling of notification messages to the start, finish and failure methods

--- a/fudge_settings.yml
+++ b/fudge_settings.yml
@@ -2,4 +2,4 @@ flay:
   max: 0
 flog:
   max: 7.6
-  average: 3.5
+  average: 4.3

--- a/lib/rake_helper.rb
+++ b/lib/rake_helper.rb
@@ -3,20 +3,17 @@ module RakeHelper
 
   # @param message [String]
   def start(message, *params)
-    message = params.empty? ? "START: #{message}" : params_to_message(params, prepend: 'START')
-    put_and_log(message: message, type: :info)
+    put_and_log(message: "START: #{obtain_message(message, *params)}", type: :info)
   end
 
   # @param message [String]
   def finish(message, *params)
-    message = params.empty? ? "FINISH: #{message}" : params_to_message(params, prepend: 'FINISH')
-    put_and_log(message: message, type: :info)
+    put_and_log(message: "FINISH: #{obtain_message(message, *params)}", type: :info)
   end
 
   # @param message [String]
   def failure(message, *params)
-    message = params.empty? ? "FAILURE: #{message}" : params_to_message(params, prepend: 'FAILURE')
-    put_and_log(message: message, type: :error)
+    put_and_log(message: "FAILURE: #{obtain_message(message, *params)}", type: :error)
   end
 
   # @param sql [String] valid SQL, can include several statements separated by semicolons
@@ -31,16 +28,21 @@ module RakeHelper
   end
 
   private
+  def obtain_message(message, *params)
+    params.empty? ? message : params_to_message(params)
+  end
 
   def put_and_log(message:, type:)
     puts "#{Time.now} #{message}"
     Rails.logger.public_send(type, message)
   end
 
-  def params_to_message(params, prepend:)
-    sql_hash = params.last
-    msg = sql_hash.is_a?(Hash) && sql_hash.key?(:sql) ? sql_hash[:sql] : 'Unidentified Call'
-    "#{prepend}: #{msg}"
+  def params_to_message(params)
+    message_from_hash(params.last)
+  end
+
+  def message_from_hash(sql_hash)
+    sql_hash.is_a?(Hash) && sql_hash[:sql] ? sql_hash[:sql] : 'Unidentified Call'
   end
 
   def method_missing(method, *args)

--- a/lib/rake_helper.rb
+++ b/lib/rake_helper.rb
@@ -2,18 +2,21 @@
 module RakeHelper
 
   # @param message [String]
-  def start(message)
-    put_and_log(message: "START: #{message}", type: :info)
+  def start(message, *params)
+    message = params.empty? ? "START: #{message}" : params_to_message(params, prepend: 'START')
+    put_and_log(message: message, type: :info)
   end
 
   # @param message [String]
-  def finish(message)
-    put_and_log(message: "FINISH: #{message}", type: :info)
+  def finish(message, *params)
+    message = params.empty? ? "FINISH: #{message}" : params_to_message(params, prepend: 'FINISH')
+    put_and_log(message: message, type: :info)
   end
 
   # @param message [String]
-  def failure(message)
-    put_and_log(message: "FAILURE: #{message}", type: :error)
+  def failure(message, *params)
+    message = params.empty? ? "FAILURE: #{message}" : params_to_message(params, prepend: 'FAILURE')
+    put_and_log(message: message, type: :error)
   end
 
   # @param sql [String] valid SQL, can include several statements separated by semicolons
@@ -32,6 +35,12 @@ module RakeHelper
   def put_and_log(message:, type:)
     puts "#{Time.now} #{message}"
     Rails.logger.public_send(type, message)
+  end
+
+  def params_to_message(params, prepend:)
+    sql_hash = params.last
+    msg = sql_hash.is_a?(Hash) && sql_hash.key?(:sql) ? sql_hash[:sql] : 'Unidentified Call'
+    "#{prepend}: #{msg}"
   end
 
   def method_missing(method, *args)

--- a/rake_helper.gemspec
+++ b/rake_helper.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'rake_helper'
-  s.version     = '1.0.0.rc1'
+  s.version     = '1.0.1'
   s.license     = 'MIT'
   s.summary     = 'A set of common helper methods to DRY up Rails rake tasks'
   s.author      = 'Daniel Chopson'

--- a/spec/lib/rake_helper_spec.rb
+++ b/spec/lib/rake_helper_spec.rb
@@ -8,6 +8,11 @@ describe RakeHelper do
   subject { DummyRake.new }
 
   let(:message) { 'message' }
+  let(:params) do
+    ['1234', { sql: query }]
+  end
+  let(:incorrect_params) { [:foo, :bar] }
+  let(:query) { 'SELECT something FROM table' }
 
   before { allow($stdout).to receive(:write) }
 
@@ -16,6 +21,16 @@ describe RakeHelper do
       expect(Rails).to receive_message_chain(:logger, :info).with(a_string_including('START'))
       subject.start(message)
     end
+
+    it 'allows for the Hash message format' do
+      expect(Rails).to receive_message_chain(:logger, :info).with(a_string_including("START: #{query}"))
+      subject.start(message, *params)
+    end
+
+    it 'with incorrect params logs, but marks the call as unidentified' do
+      expect(Rails).to receive_message_chain(:logger, :info).with(a_string_including("START: Unidentified Call"))
+      subject.start(message, *incorrect_params)
+    end
   end
 
   describe '#finish' do
@@ -23,12 +38,32 @@ describe RakeHelper do
       expect(Rails).to receive_message_chain(:logger, :info).with(a_string_including('FINISH'))
       subject.finish(message)
     end
+
+    it 'allows for the Hash message format' do
+      expect(Rails).to receive_message_chain(:logger, :info).with(a_string_including("FINISH: #{query}"))
+      subject.finish(message, *params)
+    end
+
+    it 'with incorrect params logs, but marks the call as unidentified' do
+      expect(Rails).to receive_message_chain(:logger, :info).with(a_string_including("START: Unidentified Call"))
+      subject.start(message, *incorrect_params)
+    end
   end
 
   describe '#failure' do
     it 'logs as error with the FAILURE keyword' do
       expect(Rails).to receive_message_chain(:logger, :error).with(a_string_including('FAILURE'))
       subject.failure(message)
+    end
+
+    it 'allows for the Hash message format' do
+      expect(Rails).to receive_message_chain(:logger, :error).with(a_string_including("FAILURE: #{query}"))
+      subject.failure(message, *params)
+    end
+
+    it 'with incorrect params logs, but marks the call as unidentified' do
+      expect(Rails).to receive_message_chain(:logger, :error).with(a_string_including("FAILURE: Unidentified Call"))
+      subject.failure(message, *incorrect_params)
     end
   end
 


### PR DESCRIPTION
## Problem 
When adding notification listener on initializers directly or via gem the following stack trace occured:
```
ArgumentError: wrong number of arguments (given 3, expected 1)
/usr/local/bundle/gems/rake_helper-1.0.0.rc1/lib/rake_helper.rb:5:in `start'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/notifications/fanout.rb:98:in `start'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/notifications/fanout.rb:42:in `block in start'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/notifications/fanout.rb:42:in `each'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/notifications/fanout.rb:42:in `start'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/notifications/instrumenter.rb:31:in `start'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/notifications/instrumenter.rb:18:in `instrument'
/usr/local/bundle/gems/activerecord-4.2.11.1/lib/active_record/connection_adapters/abstract_adapter.rb:478:in `log'
/usr/local/bundle/gems/activerecord-4.2.11.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:317:in `execute'
/usr/local/bundle/gems/activerecord-4.2.11.1/lib/active_record/connection_adapters/mysql2_adapter.rb:217:in `execute'
/usr/local/bundle/gems/activerecord-4.2.11.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:324:in `execute_and_free'
/usr/local/bundle/gems/activerecord-4.2.11.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:418:in `tables'
/usr/local/bundle/gems/activerecord-4.2.11.1/lib/active_record/connection_adapters/schema_cache.rb:90:in `prepare_tables'
/usr/local/bundle/gems/activerecord-4.2.11.1/lib/active_record/connection_adapters/schema_cache.rb:22:in `table_exists?'
/usr/local/bundle/gems/activerecord-4.2.11.1/lib/active_record/model_schema.rb:230:in `table_exists?'
/usr/local/bundle/gems/activerecord-4.2.11.1/lib/active_record/attribute_methods/primary_key.rb:97:in `get_primary_key'
/usr/local/bundle/gems/activerecord-4.2.11.1/lib/active_record/attribute_methods/primary_key.rb:85:in `reset_primary_key'
/usr/local/bundle/gems/activerecord-4.2.11.1/lib/active_record/attribute_methods/primary_key.rb:73:in `primary_key'
/usr/local/bundle/gems/protected_attributes-1.0.9/lib/active_record/mass_assignment_security/attribute_assignment.rb:15:in `attributes_protected_by_default'
/usr/local/bundle/gems/protected_attributes-1.0.9/lib/active_model/mass_assignment_security.rb:332:in `block in protected_attributes_configs'
/usr/local/bundle/gems/protected_attributes-1.0.9/lib/active_model/mass_assignment_security.rb:217:in `protected_attributes'
/usr/local/bundle/gems/protected_attributes-1.0.9/lib/active_model/mass_assignment_security.rb:123:in `block in attr_protected'
/usr/local/bundle/gems/protected_attributes-1.0.9/lib/active_model/mass_assignment_security.rb:122:in `each'
/usr/local/bundle/gems/protected_attributes-1.0.9/lib/active_model/mass_assignment_security.rb:122:in `attr_protected'
/usr/local/bundle/gems/sop_core_models-3.7.0/app/models/user.rb:27:in `<class:User>'
/usr/local/bundle/gems/sop_core_models-3.7.0/app/models/user.rb:2:in `<top (required)>'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:457:in `load'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:457:in `block in load_file'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:647:in `new_constants_in'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:456:in `load_file'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:354:in `require_or_load'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:494:in `load_missing_constant'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:184:in `const_missing'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:526:in `load_missing_constant'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:184:in `const_missing'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:526:in `load_missing_constant'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:184:in `const_missing'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:526:in `load_missing_constant'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:184:in `const_missing'
/usr/src/app/host_app/lib/api/v3/authentication_configurator.rb:66:in `set_business_and_user_class'
/usr/src/app/host_app/lib/api/v3/authentication_configurator.rb:19:in `call'
/usr/src/app/host_app/lib/api/v3/authentication_configurator.rb:9:in `call'
/usr/src/app/host_app/config/initializers/s1_api_auth.rb:1:in `<top (required)>'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:268:in `load'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:268:in `block in load'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:240:in `load_dependency'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:268:in `load'
/usr/local/bundle/gems/railties-4.2.11.1/lib/rails/engine.rb:652:in `block in load_config_initializer'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/notifications.rb:166:in `instrument'
/usr/local/bundle/gems/railties-4.2.11.1/lib/rails/engine.rb:651:in `load_config_initializer'
/usr/local/bundle/gems/railties-4.2.11.1/lib/rails/engine.rb:616:in `block (2 levels) in <class:Engine>'
/usr/local/bundle/gems/railties-4.2.11.1/lib/rails/engine.rb:615:in `each'
/usr/local/bundle/gems/railties-4.2.11.1/lib/rails/engine.rb:615:in `block in <class:Engine>'
/usr/local/bundle/gems/railties-4.2.11.1/lib/rails/initializable.rb:30:in `instance_exec'
/usr/local/bundle/gems/railties-4.2.11.1/lib/rails/initializable.rb:30:in `run'
/usr/local/bundle/gems/railties-4.2.11.1/lib/rails/initializable.rb:55:in `block in run_initializers'
/usr/local/bundle/gems/railties-4.2.11.1/lib/rails/initializable.rb:44:in `each'
/usr/local/bundle/gems/railties-4.2.11.1/lib/rails/initializable.rb:44:in `tsort_each_child'
/usr/local/bundle/gems/railties-4.2.11.1/lib/rails/initializable.rb:54:in `run_initializers'
/usr/local/bundle/gems/railties-4.2.11.1/lib/rails/application.rb:352:in `initialize!'
/usr/src/app/host_app/config/environment.rb:5:in `<top (required)>'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:274:in `require'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:274:in `block in require'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:240:in `load_dependency'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:274:in `require'
/usr/local/bundle/gems/railties-4.2.11.1/lib/rails/application.rb:328:in `require_environment!'
/usr/local/bundle/gems/railties-4.2.11.1/lib/rails/application.rb:457:in `block in run_tasks_blocks'
/usr/local/bundle/gems/rake-12.3.3/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:30:in `block in <main>'
/usr/local/bin/bundle:22:in `<main>'
```
## Cause
For whatever reason RakeHelper was among the listeners for `sql.activerecord` which caused it to receive standard params of notification for which he was not prepared

## Solution
Added handling of notification messages to the `start`, `finish` and `failure` methods by extending its arity
